### PR TITLE
[RELEASE] Reducer/1.1.0

### DIFF
--- a/Sources/Reducer/Mutator.swift
+++ b/Sources/Reducer/Mutator.swift
@@ -1,0 +1,70 @@
+//
+//  Mutator.swift
+//  
+//
+//  Created by JSilver on 2023/03/31.
+//
+
+import Combine
+
+@MainActor
+public protocol Mutator<Mutation, State>: AnyObject {
+    associatedtype Mutation
+    associatedtype State
+    
+    var state: State { get }
+    var initialState: State { get }
+    
+    var cancellableBag: Set<AnyCancellable> { get set }
+    
+    func mutate(_ mutation: Mutation)
+}
+
+public extension Mutator {
+    func callAsFunction(_ mutation: Mutation) {
+        mutate(mutation)
+    }
+}
+
+final class ProxyMutator<M: Mutator>: Mutator {
+    typealias Mutation = M.Mutation
+    typealias State = M.State
+    
+    // MARK: - Propery
+    private let _state: () -> State
+    var state: State { _state() }
+    let initialState: State
+    
+    private let _cancellableBag: UnsafeMutablePointer<Set<AnyCancellable>>
+    var cancellableBag: Set<AnyCancellable> {
+        get {
+            _cancellableBag.pointee
+        }
+        set {
+            _cancellableBag.pointee = newValue
+        }
+    }
+    
+    private let _mutate: ((Mutation) -> Void)?
+    
+    // MARK: - Initializer
+    init(_ mutator: M) {
+        let initialState = mutator.initialState
+        
+        self.initialState = initialState
+        self._state = { [weak mutator] in mutator?.state ?? initialState }
+        
+        self._cancellableBag = withUnsafeMutablePointer(to: &mutator.cancellableBag) { $0 }
+        
+        self._mutate = { [weak mutator] mutation in mutator?.mutate(mutation)}
+    }
+    
+    // MARK: - Lifecycle
+    func mutate(_ mutation: Mutation) {
+        _mutate?(mutation)
+    }
+    
+    // MARK: - Public
+    
+    // MARK: - Private
+}

--- a/Sources/Reducer/Reduce.swift
+++ b/Sources/Reducer/Reduce.swift
@@ -5,23 +5,8 @@
 //  Created by JSilver on 2023/03/07.
 //
 
-import Foundation
+import Combine
 
-// MARK: - Mutator
-@MainActor
-public protocol Mutator<Mutation>: AnyObject {
-    associatedtype Mutation
-    
-    func mutate(_ mutation: Mutation)
-}
-
-public extension Mutator {
-    func callAsFunction(_ mutation: Mutation) {
-        mutate(mutation)
-    }
-}
-
-// MARK: - Reduce
 @MainActor
 public protocol Reduce: AnyObject {
     associatedtype Action
@@ -31,8 +16,10 @@ public protocol Reduce: AnyObject {
     typealias ActionItem = (state: State, action: Action)
     typealias Mutate = (Mutation) -> Void
     
-    var mutator: (any Mutator<Mutation>)? { get set }
+    var mutator: (any Mutator<Mutation, State>)? { get set }
     var initialState: State { get }
+    
+    func start(with mutator: any Mutator<Mutation, State>)
     
     func mutate(state: State, action: Action) async throws
     func reduce(state: State, mutation: Mutation) -> State
@@ -40,6 +27,10 @@ public protocol Reduce: AnyObject {
 }
 
 public extension Reduce {
+    func start(with mutator: any Mutator<Mutation, State>) {
+        
+    }
+    
     func shouldCancel(_ current: ActionItem, _ upcoming: ActionItem) -> Bool {
         false
     }
@@ -55,56 +46,74 @@ extension Reduce {
     }
 }
 
-// MARK: - ProxyReduce
 open class ProxyReduce<R: Reduce>: Reduce {
     public typealias Action = R.Action
     public typealias Mutation = R.Mutation
     public typealias State = R.State
     
     // MARK: - Property
-    public weak var mutator: (any Mutator<Mutation>)? {
+    public var mutator: (any Mutator<Mutation, State>)? {
         didSet {
-            reduce?.mutator = mutator
+            _setMutator?(mutator)
         }
     }
     public var initialState: State
     
-    private let reduce: R?
+    private let _setMutator: (((any Mutator<Mutation, State>)?) -> Void)?
+    
+    private let _start: ((any Mutator<Mutation, State>) -> Void)?
     private let _mutate: ((State, Action, @escaping Mutate) async throws -> Void)?
     private let _reduce: ((State, Mutation) -> State)?
     private let _shouldCancel: ((ActionItem, ActionItem) -> Bool)?
     
     // MARK: - Initalizer
-    public init(_ reduce: R) {
-        self.initialState = reduce.initialState
-        self.reduce = reduce
-        
-        self._mutate = { state, action, _ in
-            try await reduce.mutate(state: state, action: action)
-        }
-        self._reduce = { state, mutation in
-            reduce.reduce(state: state, mutation: mutation)
-        }
-        self._shouldCancel = { current, upcoming in
-            reduce.shouldCancel(current, upcoming)
-        }
-    }
-    
     public init(
         initialState: State,
+        setMutator: (((any Mutator<Mutation, State>)?) -> Void)? = nil,
+        start: ((any Mutator<Mutation, State>) -> Void)? = nil,
         mutate: ((State, Action, @escaping Mutate) async throws -> Void)? = nil,
         reduce: ((State, Mutation) -> State)? = nil,
         shouldCancel: (((state: State, action: Action), (state: State, action: Action)) -> Bool)? = nil
     ) {
         self.initialState = initialState
-        self.reduce = nil
         
+        self._setMutator = setMutator
+        
+        self._start = start
         self._mutate = mutate
         self._reduce = reduce
         self._shouldCancel = shouldCancel
     }
     
-    // MARK: - Public
+    convenience init(_ reduce: R) {
+        self.init(
+            initialState: reduce.initialState,
+            setMutator: { mutator in
+                reduce.mutator = mutator
+            },
+            start: { mutator in
+                reduce.start(with: mutator)
+            },
+            mutate: { state, action, _ in
+                try await reduce.mutate(state: state, action: action)
+            },
+            reduce: { state, mutation in
+                reduce.reduce(state: state, mutation: mutation)
+            },
+            shouldCancel: { current, upcoming in
+                reduce.shouldCancel(current, upcoming)
+            }
+        )
+    }
+    
+    // MARK: - Lifecycle
+    open func start(with mutator: any Mutator<Mutation, State>) {
+        self.mutator = mutator
+        
+        weak var weakMutator = mutator
+        _start?(weakMutator!)
+    }
+    
     open func mutate(state: State, action: Action) async throws {
         try await _mutate?(
             state,
@@ -121,4 +130,8 @@ open class ProxyReduce<R: Reduce>: Reduce {
     open func shouldCancel(_ current: ActionItem, _ upcoming: ActionItem) -> Bool {
         _shouldCancel?(current, upcoming) ?? false
     }
+    
+    // MARK: - Public
+    
+    // MARK: - Private
 }

--- a/Sources/Reducer/Reducer.swift
+++ b/Sources/Reducer/Reducer.swift
@@ -90,7 +90,9 @@ open class Reducer<R: Reduce>: ObservableObject, Mutator {
         self.initialState = reduce.initialState
         
         // Start reduce with mutator.
-        self.reduce.start(with: ProxyMutator(self))
+        Task {
+            try await self.reduce.start(with: ProxyMutator(self))
+        }
     }
     
     public convenience init(_ reduce: R) {

--- a/Tests/ReducerTests/Model/AwaitStartReduce.swift
+++ b/Tests/ReducerTests/Model/AwaitStartReduce.swift
@@ -1,5 +1,5 @@
 //
-//  TimerReduce.swift
+//  AwaitStartReduce.swift
 //  
 //
 //  Created by JSilver on 2023/03/31.
@@ -8,7 +8,7 @@
 import Foundation
 import Reducer
 
-class TimerReduce: Reduce {
+class AwaitStartReduce: Reduce {
     enum Action {
         case empty
     }
@@ -32,10 +32,8 @@ class TimerReduce: Reduce {
 
     // MARK: - Lifecycle
     func start(with mutator: any Mutator<Mutation, State>) async throws {
-        Timer.publish(every: 0.1, on: .main, in: .default)
-            .autoconnect()
-            .sink { _ in mutator(.increase) }
-            .store(in: &mutator.cancellableBag)
+        try await Task.sleep(nanoseconds: 10_000_000)
+        mutator.mutate(.increase)
     }
     
     func mutate(state: State, action: Action) async throws {

--- a/Tests/ReducerTests/Model/CountSetReduce.swift
+++ b/Tests/ReducerTests/Model/CountSetReduce.swift
@@ -21,7 +21,7 @@ class CountSetReduce: Reduce {
     }
 
     // MARK: - Property
-    weak var mutator: (any Mutator<Mutation>)?
+    var mutator: (any Mutator<Mutation, State>)?
     var initialState: State
 
     // MARK: - Initializer

--- a/Tests/ReducerTests/Model/TimerReduce.swift
+++ b/Tests/ReducerTests/Model/TimerReduce.swift
@@ -1,15 +1,16 @@
 //
-//  CountIncreaseReduce.swift
+//  TimerReduce.swift
 //  
 //
-//  Created by JSilver on 2023/03/07.
+//  Created by JSilver on 2023/03/31.
 //
 
+import Foundation
 import Reducer
 
-class CountIncreaseReduce: Reduce {
+class TimerReduce: Reduce {
     enum Action {
-        case increase
+        case empty
     }
 
     enum Mutation {
@@ -30,13 +31,15 @@ class CountIncreaseReduce: Reduce {
     }
 
     // MARK: - Lifecycle
+    func start(with mutator: any Mutator<Mutation, State>) {
+        Timer.publish(every: 0.1, on: .main, in: .default)
+            .autoconnect()
+            .sink { _ in mutator(.increase) }
+            .store(in: &mutator.cancellableBag)
+    }
+    
     func mutate(state: State, action: Action) async throws {
-        switch action {
-        case .increase:
-            // Increase count after waiting 0.1 sec.
-            try await Task.sleep(nanoseconds: 10_000_000)
-            mutate(.increase)
-        }
+        
     }
 
     func reduce(state: State, mutation: Mutation) -> State {

--- a/Tests/ReducerTests/ReducerTests.swift
+++ b/Tests/ReducerTests/ReducerTests.swift
@@ -110,6 +110,22 @@ final class ReducerTests: XCTestCase {
         XCTAssertGreaterThan(result.last ?? 0, 0)
     }
     
+    func test_that_count_increases_when_await_mutate_in_start() async throws {
+        // Given
+        let reducer = Reducer(AwaitStartReduce(
+            initialState: .init(count: 0)
+        ))
+        
+        // When
+        let result = try await wait(
+            reducer.$state.map(\.count),
+            timeout: 1
+        )
+        
+        // Then
+        XCTAssertEqual(result, [0, 1])
+    }
+    
     func test_that_reducer_should_be_able_to_assign_proxy_reduce() async throws {
         // Given
         var reducer = Reducer(CountIncreaseReduce(


### PR DESCRIPTION
# 📌 Reference
> Add any references to help understand this pull request.


# 🔥 Cause
> If there is a reason, write why the code changes was occurred.


# 📄 Changes
> Write what is changed.
> You can write more detail informations using MD syntax.

### Added
- Added `start(with:)` function that initialize reduce with mutator into `Reduce`. See more README.

### Changed
- No more add weak keyword on `Reduce`'s mutator property.
  ```swift
  // until 1.0.0
  weak var mutator: (any Mutator<Mutation, State>)? // ❌
  // after 1.1.0
  var mutator: (any Mutator<Mutation, State>)? // ✅
  ``` 

# 🚧 Testing
> Write how to test and results of changes using screenshots, gifs, any others.
