### PR TITLE
[] Fixed app crash on iOS 15.

### DIFF
--- a/Sources/Reducer/Reducer.swift
+++ b/Sources/Reducer/Reducer.swift
@@ -67,7 +67,7 @@ final class TaskBag<Item> {
     }
 }
 
-open class Reducer<R: Reduce>: ObservableObject, Mutator {
+open class Reducer<R: Reduce>: ObservableObject, Mutable {
     public typealias Action = R.Action
     public typealias Mutation = R.Mutation
     public typealias State = R.State
@@ -91,7 +91,7 @@ open class Reducer<R: Reduce>: ObservableObject, Mutator {
         
         // Start reduce with mutator.
         Task {
-            try await self.reduce.start(with: ProxyMutator(self))
+            try await self.reduce.start(with: Mutator(self))
         }
     }
     

--- a/Tests/ReducerTests/Model/AwaitStartReduce.swift
+++ b/Tests/ReducerTests/Model/AwaitStartReduce.swift
@@ -22,7 +22,7 @@ class AwaitStartReduce: Reduce {
     }
 
     // MARK: - Property
-    var mutator: (any Mutator<Mutation, State>)?
+    var mutator: Mutator<Mutation, State>?
     var initialState: State
 
     // MARK: - Initializer
@@ -31,7 +31,7 @@ class AwaitStartReduce: Reduce {
     }
 
     // MARK: - Lifecycle
-    func start(with mutator: any Mutator<Mutation, State>) async throws {
+    func start(with mutator: Mutator<Mutation, State>) async throws {
         try await Task.sleep(nanoseconds: 10_000_000)
         mutator.mutate(.increase)
     }

--- a/Tests/ReducerTests/Model/CountIncreaseReduce.swift
+++ b/Tests/ReducerTests/Model/CountIncreaseReduce.swift
@@ -21,7 +21,7 @@ class CountIncreaseReduce: Reduce {
     }
 
     // MARK: - Property
-    var mutator: (any Mutator<Mutation, State>)?
+    var mutator: Mutator<Mutation, State>?
     var initialState: State
 
     // MARK: - Initializer

--- a/Tests/ReducerTests/Model/CountSetReduce.swift
+++ b/Tests/ReducerTests/Model/CountSetReduce.swift
@@ -21,7 +21,7 @@ class CountSetReduce: Reduce {
     }
 
     // MARK: - Property
-    var mutator: (any Mutator<Mutation, State>)?
+    var mutator: Mutator<Mutation, State>?
     var initialState: State
 
     // MARK: - Initializer

--- a/Tests/ReducerTests/Model/TimerReduce.swift
+++ b/Tests/ReducerTests/Model/TimerReduce.swift
@@ -22,7 +22,7 @@ class TimerReduce: Reduce {
     }
 
     // MARK: - Property
-    var mutator: (any Mutator<Mutation, State>)?
+    var mutator: Mutator<Mutation, State>?
     var initialState: State
 
     // MARK: - Initializer
@@ -31,7 +31,7 @@ class TimerReduce: Reduce {
     }
 
     // MARK: - Lifecycle
-    func start(with mutator: any Mutator<Mutation, State>) async throws {
+    func start(with mutator: Mutator<Mutation, State>) async throws {
         Timer.publish(every: 0.1, on: .main, in: .default)
             .autoconnect()
             .sink { _ in mutator(.increase) }


### PR DESCRIPTION
- applied changes to test cases

# 📌 Reference
> Add any references to help understand this pull request.


# 🔥 Cause
> If there is a reason, write why the code changes was occurred.

Before version 1.3.0 of `Reducer`, a crash may occur on iOS 15 when using constrained existential type.

The exact situation is that a closure with constrained existential type is defined as a parameter with the `async` keyword and built with package.

This looks like a `Swift` bug.

# 📄 Changes
> Write what is changed.
> You can write more detail informations using MD syntax.

Replace `any Mutator<Mutation, State>` constrained existential type to `Mutator<Mutation, State>` generic class.

# 🚧 Testing
> Write how to test and results of changes using screenshots, gifs, any others.

`all tests succeeded`