### PR TITLE
[] Reducer interface improvements.

### DIFF
--- a/Sources/Reducer/Reduce.swift
+++ b/Sources/Reducer/Reduce.swift
@@ -114,6 +114,7 @@ open class ProxyReduce<R: Reduce>: Reduce {
             }
         )
         
+        // Set flag to false to indicate mutator pointer deallocated.
         _mutator.deallocate()
         isMutatorAllocated = false
         
@@ -143,6 +144,7 @@ open class ProxyReduce<R: Reduce>: Reduce {
     
     deinit {
         if isMutatorAllocated {
+            // Deallocate pointer when mutator allocated.
             _mutator.deallocate()
         }
     }

--- a/Sources/Reducer/Reducer.swift
+++ b/Sources/Reducer/Reducer.swift
@@ -13,10 +13,10 @@ final class TaskBag<Item> {
     struct TaskItem: Hashable {
         // MARK: - Property
         let item: Item
-        let task: Task<Void?, Never>
+        let task: Task<Void, Never>
         
         // MARK: - Initalizer
-        init(_ item: Item, with task: Task<Void?, Never>) {
+        init(_ item: Item, with task: Task<Void, Never>) {
             self.item = item
             self.task = task
         }
@@ -46,18 +46,14 @@ final class TaskBag<Item> {
     func store(_ item: TaskItem) {
         items.insert(item)
         
-        Task { [weak self] in
+        Task {
             await item.task.value
-            self?.remove(item)
+            items.remove(item)
         }
     }
     
     func forEach(_ body: (TaskItem) throws -> Void) rethrows {
         try items.forEach(body)
-    }
-    
-    func remove(_ item: TaskItem) {
-        items.remove(item)
     }
     
     // MARK: - Private
@@ -75,23 +71,20 @@ open class Reducer<R: Reduce>: ObservableObject, Mutable {
     // MARK: - Property
     @Published
     public private(set) var state: State
-    public let initialState: State
     
     private let reduce: ProxyReduce<R>
     
-    public var cancellableBag = Set<AnyCancellable>()
-    private let taskBag = TaskBag<R.ActionItem>()
+    private let taskBag = TaskBag<R.Action>()
     
     // MARK: - Initalizer
     public init(proxy reduce: ProxyReduce<R>) {
+        self.state = reduce.initialState
         self.reduce = reduce
         
-        self.state = reduce.initialState
-        self.initialState = reduce.initialState
-        
         // Start reduce with mutator.
+        reduce.mutator = Mutator(self, initialState: reduce.initialState)
         Task {
-            try await self.reduce.start(with: Mutator(self))
+            try? await reduce.start()
         }
     }
     
@@ -100,39 +93,28 @@ open class Reducer<R: Reduce>: ObservableObject, Mutable {
     }
     
     // MARK: - Lifecycle
-    public func mutate(_ mutation: Mutation) {
-        Task {
-            // Reduce state from mutation.
-            // Run task on main actor context.
-            reduce(mutation: mutation)
-        }
+    open func mutate(_ mutation: Mutation) {
+        // Reduce state from mutation.
+        // Run task on main actor context.
+        state = reduce(state: state, mutation: mutation)
     }
     
     // MARK: - Public
-    public func action(_ action: Action) {
+    open func action(_ action: Action) {
         let reduce = reduce
-        let state = state
         
-        taskBag.forEach {
-            guard reduce.shouldCancel($0.item, (state, action)) else { return }
-            $0.cancel()
+        taskBag.forEach { task in
+            guard reduce.shouldCancel(task.item, action) else { return }
+            task.cancel()
         }
         
         // Store task into bag.
         taskBag.store(.init(
-            (state, action),
+            action,
             with: Task {
                 // Mutate state from action.
-                try? await reduce.mutate(
-                    state: state,
-                    action: action
-                )
+                try? await reduce.mutate(action: action)
             }
         ))
-    }
-    
-    // MARK: - Private
-    private func reduce(mutation: Mutation) {
-        state = reduce(state: state, mutation: mutation)
     }
 }

--- a/Tests/ReducerTests/Model/AwaitStartReduce.swift
+++ b/Tests/ReducerTests/Model/AwaitStartReduce.swift
@@ -8,7 +8,9 @@
 import Foundation
 import Reducer
 
-class AwaitStartReduce: Reduce {
+@Reduce
+@MainActor
+class AwaitStartReduce {
     enum Action {
         case empty
     }
@@ -22,8 +24,7 @@ class AwaitStartReduce: Reduce {
     }
 
     // MARK: - Property
-    var mutator: Mutator<Mutation, State>?
-    var initialState: State
+    let initialState: State
 
     // MARK: - Initializer
     init(initialState: State) {
@@ -31,12 +32,12 @@ class AwaitStartReduce: Reduce {
     }
 
     // MARK: - Lifecycle
-    func start(with mutator: Mutator<Mutation, State>) async throws {
+    func start() async throws {
         try await Task.sleep(nanoseconds: 10_000_000)
-        mutator.mutate(.increase)
+        mutate(.increase)
     }
     
-    func mutate(state: State, action: Action) async throws {
+    func mutate(action: Action) async throws {
         
     }
 

--- a/Tests/ReducerTests/Model/CountIncreaseReduce.swift
+++ b/Tests/ReducerTests/Model/CountIncreaseReduce.swift
@@ -7,7 +7,9 @@
 
 import Reducer
 
-class CountIncreaseReduce: Reduce {
+@Reduce
+@MainActor
+class CountIncreaseReduce {
     enum Action {
         case increase
     }
@@ -21,8 +23,7 @@ class CountIncreaseReduce: Reduce {
     }
 
     // MARK: - Property
-    var mutator: Mutator<Mutation, State>?
-    var initialState: State
+    let initialState: State
 
     // MARK: - Initializer
     init(initialState: State) {
@@ -30,7 +31,7 @@ class CountIncreaseReduce: Reduce {
     }
 
     // MARK: - Lifecycle
-    func mutate(state: State, action: Action) async throws {
+    func mutate(action: Action) async throws {
         switch action {
         case .increase:
             // Increase count after waiting 0.1 sec.

--- a/Tests/ReducerTests/Model/CountSetReduce.swift
+++ b/Tests/ReducerTests/Model/CountSetReduce.swift
@@ -7,7 +7,9 @@
 
 import Reducer
 
-class CountSetReduce: Reduce {
+@Reduce
+@MainActor
+class CountSetReduce {
     enum Action {
         case increase
     }
@@ -21,8 +23,7 @@ class CountSetReduce: Reduce {
     }
 
     // MARK: - Property
-    var mutator: Mutator<Mutation, State>?
-    var initialState: State
+    let initialState: State
 
     // MARK: - Initializer
     init(initialState: State) {
@@ -30,12 +31,12 @@ class CountSetReduce: Reduce {
     }
 
     // MARK: - Lifecycle
-    func mutate(state: State, action: Action) async throws {
+    func mutate(action: Action) async throws {
         switch action {
         case .increase:
             // Increase count after waiting 0.1 sec.
             try await Task.sleep(nanoseconds: 10_000_000)
-            mutate(.setCount(state.count + 1))
+            mutate(.setCount(currentState.count + 1))
         }
     }
 
@@ -49,8 +50,8 @@ class CountSetReduce: Reduce {
         }
     }
 
-    func shouldCancel(_ current: ActionItem, _ upcoming: ActionItem) -> Bool {
+    func shouldCancel(_ current: Action, _ upcoming: Action) -> Bool {
         // Cancel previous action when same action occured.
-        current.action == upcoming.action
+        current == upcoming
     }
 }

--- a/Tests/ReducerTests/Model/ProxyCountIncrease10Reduce.swift
+++ b/Tests/ReducerTests/Model/ProxyCountIncrease10Reduce.swift
@@ -8,7 +8,7 @@
 import Reducer
 
 class ProxyCountIncrease10Reduce: ProxyReduce<CountIncreaseReduce> {
-    override func mutate(state: State, action: Action) async throws {
+    override func mutate(action: Action) async throws {
         switch action {
         case .increase:
             try await Task.sleep(nanoseconds: 100_000_000)

--- a/Tests/ReducerTests/Model/TimerReduce.swift
+++ b/Tests/ReducerTests/Model/TimerReduce.swift
@@ -7,8 +7,11 @@
 
 import Foundation
 import Reducer
+import Combine
 
-class TimerReduce: Reduce {
+@Reduce
+@MainActor
+class TimerReduce {
     enum Action {
         case empty
     }
@@ -22,8 +25,9 @@ class TimerReduce: Reduce {
     }
 
     // MARK: - Property
-    var mutator: Mutator<Mutation, State>?
-    var initialState: State
+    let initialState: State
+    
+    private var cancellableBag = Set<AnyCancellable>()
 
     // MARK: - Initializer
     init(initialState: State) {
@@ -31,14 +35,16 @@ class TimerReduce: Reduce {
     }
 
     // MARK: - Lifecycle
-    func start(with mutator: Mutator<Mutation, State>) async throws {
+    func start() async throws {
+        cancellableBag.removeAll()
+        
         Timer.publish(every: 0.1, on: .main, in: .default)
             .autoconnect()
-            .sink { _ in mutator(.increase) }
-            .store(in: &mutator.cancellableBag)
+            .sink { [weak self] _ in self?.mutate(.increase) }
+            .store(in: &cancellableBag)
     }
     
-    func mutate(state: State, action: Action) async throws {
+    func mutate(action: Action) async throws {
         
     }
 

--- a/Tests/ReducerTests/ReducerTests.swift
+++ b/Tests/ReducerTests/ReducerTests.swift
@@ -278,7 +278,7 @@ final class ReducerTests: XCTestCase {
                 }
             },
             shouldCancel: { current, upcoming in
-                current.action == upcoming.action
+                current == upcoming
             }
         ))
         
@@ -298,13 +298,13 @@ final class ReducerTests: XCTestCase {
     
     func test_that_count_increases_when_proxy_mutate_in_start() async throws {
         // Given
+        var cancellable: AnyCancellable? = nil
         let reducer = Reducer<TimerReduce>(proxy: .init(
             initialState: .init(count: 0),
-            start: { mutator in
-                Timer.publish(every: 0.1, on: .main, in: .default)
+            start: { mutate in
+                cancellable = Timer.publish(every: 0.1, on: .main, in: .default)
                     .autoconnect()
-                    .sink { _ in mutator(.increase) }
-                    .store(in: &mutator.cancellableBag)
+                    .sink { _ in mutate(.increase) }
             },
             reduce: { state, mutation in
                 var state = state


### PR DESCRIPTION
# 📌 Reference
> Add any references to help understand this pull request.


# 🔥 Cause
> If there is a reason, write why the code changes was occurred.


# 📄 Changes
> Write what is changed.
> You can write more detail informations using MD syntax.

Improved unnecessary interfaces.
- The `mutate` method does not pass the current state. </br></br>
  ```swift
  func mutate(state: State, action: Action) async throws { } // ❌
  func mutate(action: Action) async throws { } // ✅
  ```
  But you can still access the state with the `currentState` property. </br></br>
  ```swift
  func mutate(action: Action) async throws {
      switch action {
      case .increase:
          mutate(.setCount(currentState.count + 1))
      }
  }
  ```
- The `start` method doesn't pass any parameters. </br></br>
  ```swift
  func start(with mutator: any Mutator<Mutation, State>) async throws { } // ❌
  func start() async throws { } // ✅
  ```
  But you can still access `state` or mutate using `Reduce` methods. </br></br>
  ```swift
  func start() async throws {
      Timer.publish(every: 1, on: .main, in: .default)
          .autoconnect()
          .sink { [weak self] _ in
              guard let self else { return }
              mutate(.setCount(currentState.count + 1))
          }
  }
  ```
- The `shouldCancel` method pass only `Action` as parameter. </br></br>
  ```swift
  func shouldCancel(_ current: ActionItem, _ upcoming: ActionItem) async throws { } // ❌
  func shouldCancel(_ current: Action, _ upcoming: Action) async throws { } // ✅
  ```

# 🚧 Testing
> Write how to test and results of changes using screenshots, gifs, any others.

✅ All test cases passed.
