### PR TITLE
[] Fix to deinit the `TaskBag` even if there is a running `Task`.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax.git",
       "state" : {
-        "revision" : "e42bece52df2496d60b1b2a762fee9ffde7fc205",
-        "version" : "509.0.0-swift-DEVELOPMENT-SNAPSHOT-2023-08-07-a"
+        "revision" : "6ad4ea24b01559dde0773e3d091f1b9e36175036",
+        "version" : "509.0.2"
       }
     }
   ],

--- a/Sources/Reducer/Reducer.swift
+++ b/Sources/Reducer/Reducer.swift
@@ -45,9 +45,12 @@ final class TaskBag<Item> {
     func store(_ item: TaskItem) {
         items.insert(item)
         
+        let ref = UnsafeMutablePointer<Set<TaskItem>?>.allocate(capacity: 1)
+        ref.pointee = items
+        
         Task {
             await item.task.value
-            items.remove(item)
+            ref.pointee?.remove(item)
         }
     }
     

--- a/Tests/ReducerTests/TaskBagTests.swift
+++ b/Tests/ReducerTests/TaskBagTests.swift
@@ -1,0 +1,49 @@
+//
+//  TaskBagTests.swift
+//
+//
+//  Created by jsilver on 11/5/23.
+//
+
+import XCTest
+@testable import Reducer
+import Combine
+
+@MainActor
+final class TaskBagTests: XCTestCase {
+    // MARK: - Property
+    
+    // MARK: - Lifecycle
+    override func setUp() {
+        
+    }
+    
+    override func tearDown() {
+        
+    }
+    
+    // MARK: - Test
+    func test_that_task_bag_cancel_all_task_when_deinit() async throws {
+        // Given
+        let expectation = expectation(description: "")
+        
+        var taskBag: TaskBag? = TaskBag<Int>()
+        
+        // When
+        taskBag?.store(.init(
+            1,
+            with: Task {
+                do {
+                    try await Task.sleep(nanoseconds: 1_000_000_000)
+                } catch {
+                    expectation.fulfill()
+                }
+            }
+        ))
+        
+        taskBag = nil
+        
+        // Then
+        await fulfillment(of: [expectation], timeout: 3)
+    }
+}


### PR DESCRIPTION
# 📌 Reference
> Add any references to help understand this pull request.


# 🔥 Cause
> If there is a reason, write why the code changes was occurred.

In `store(_:)` function, `self` capture occurred in `Task` closure. So when the `Reducer` is deinited, the `TaskBag` is not deinit.

# 📄 Changes
> Write what is changed.
> You can write more detail informations using MD syntax.

Fix to capture reference of `items` of `TaskBag` in `Task` closure.

# 🚧 Testing
> Write how to test and results of changes using screenshots, gifs, any others.

- Added `test_that_task_bag_cancel_all_task_when_deinit` case.
- All test passed ✅